### PR TITLE
Feature/pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: trailing-whitespace # Убирает лишние пробелы
+    - id: end-of-file-fixer # Добавляет пустую строку в конце файла
+    - id: check-yaml # Проверяет синтаксис .yaml файлов
+    - id: check-added-large-files # Проверяет, не добавляются ли большие файлы.
+      args: ['--maxkb=300']  # максимальный размер добавляемого файла 300 кБ
+
+# Линтер black
+-   repo: https://github.com/ambv/black
+    rev: 22.10.0
+    hooks:
+    - id: black
+      language_version: python3.10
+      include: ^src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,6 @@ repos:
     hooks:
     - id: black
       language_version: python3.10
-      include: ^src/
+      args:
+        - --line-length=89
+        - --include=src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     - id: check-yaml # Проверяет синтаксис .yaml файлов
     - id: check-added-large-files # Проверяет, не добавляются ли большие файлы.
       args: ['--maxkb=300']  # максимальный размер добавляемого файла 300 кБ
+    - id: check-merge-conflict # Проверяет, нет ли файлов, содержащих конфликтующие строки слияния.
 
 # Линтер black
 -   repo: https://github.com/ambv/black

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework~=3.14.0
 python-dotenv~=1.0.0
 black~=23.7.0
 psycopg2~=2.9.6
+pre-commit~=3.3.3


### PR DESCRIPTION
Добавление pre-commit (https://pre-commit.com/).

1. Установить:
`pip install pre-commit`

2. В корне проекта выполните:
`pre-commit install`

Первый раз после коммита будет долго работать, будут загружаться зависимости, потом быстро.
Как работает. Делаем коммит как обычно и запускается проверка согласно файла .pre-commit-config.yaml Если есть какие либо несоответствия (например отсутствует пустая строка в конце файла), то при возможности они (замечания) устраняются (добавляется пустая строка), но коммит автоматически все равно не проходит (т.к. вносились изменения в файлы) повторно делаем коммит и все проходит.
Ну а если никаких несоответствий не выявлено, то коммит сразу выполняется.
Всё это видно в git логах.