### PR TITLE
feat: add pre-commit hooks check makemigrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,13 @@ repos:
       args:
         - --line-length=79
         - --include=src/
+
+# Проверяет есть ли изменения в моделях не зафиксированные в миграциях
+-   repo: local
+    hooks:
+    - id: pre-commit-check-makemigrations
+      name: Check django migrations
+      entry: ./src/manage.py makemigrations --check --dry-run
+      language: system
+      types: [python]
+      pass_filenames: false


### PR DESCRIPTION
Добавлен хук в pre-commit, который проверяет есть ли изменения в моделях не зафиксированные в миграциях.
Защита от того, что сделали изменения в моделях но не сделали makemigrations. 

Данный хук самостоятельно не делает миграции (вдруг это были ошибочные изменения), а только предупреждает, о том что нужно сделать makemigrations.